### PR TITLE
Separate logging of phrases

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,7 +57,7 @@ def grounding_dino_detect(model, device, image, prompt, id_from_phrase):
             num_phrases = len(id_from_phrase)
             id_from_phrase[phrase] = num_phrases + 1
 
-    box_ids = [id_from_phrase[phrase] for phrase in box_phrases]
+    box_ids = torch.tensor([id_from_phrase[phrase] for phrase in box_phrases])
 
     # Make sure we have an AnnotationInfo present for every class-id used in this image
     rr.log_annotation_context(
@@ -67,10 +67,20 @@ def grounding_dino_detect(model, device, image, prompt, id_from_phrase):
         timeless=False,
     )
 
+    for phrase in id_from_phrase:
+        mask = box_ids == id_from_phrase[phrase]
+        entity_path = f"image/phrases/{phrase}/detections"
+        rr.log_cleared(entity_path)
+        rr.log_rects(
+            entity_path,
+            rects=boxes_filt[mask].numpy(),
+            class_ids=box_ids[mask].numpy(),
+            rect_format=rr.RectFormat.XYXY,
+        )
     rr.log_rects(
         "image/detections",
         rects=boxes_filt.numpy(),
-        class_ids=box_ids,
+        class_ids=box_ids.numpy(),
         rect_format=rr.RectFormat.XYXY,
     )
 

--- a/main.py
+++ b/main.py
@@ -103,7 +103,10 @@ def log_video_segmentation(args, model: GroundingDINO, predictor: Sam):
         rgb = resize_img(rgb, 512)
         rr.log_image("image", rgb)
 
+        # clear everything, otherwise we'll see previous detection while inference runs
         for phrase in id_from_phrase:
+            rr.log_cleared("image/segmentation")
+            rr.log_cleared("image/detections")
             rr.log_cleared(f"image/phrases/{phrase}/segmentation")
             rr.log_cleared(f"image/phrases/{phrase}/detections")
         

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from segment_anything import SamPredictor
 from segment_anything.modeling import Sam
 from groundingdino.models import GroundingDINO
 
+
 def log_images_segmentation(args, model: GroundingDINO, predictor: Sam):
     id_from_phrase = {}
     for n, image_uri in enumerate(args.images):
@@ -93,7 +94,9 @@ def log_video_segmentation(args, model: GroundingDINO, predictor: Sam):
         rgb = resize_img(rgb, 512)
         rr.log_image("image", rgb)
         
-        detections, phrases = grounding_dino_detect(model, args.device, rgb, args.prompt, id_from_phrase)
+        detections, phrases = grounding_dino_detect(
+            model, args.device, rgb, args.prompt, id_from_phrase
+        )
 
         predictor.set_image(rgb)
         run_segmentation(predictor, rgb, detections, phrases, id_from_phrase)

--- a/main.py
+++ b/main.py
@@ -67,16 +67,15 @@ def grounding_dino_detect(model, device, image, prompt, id_from_phrase):
         timeless=False,
     )
 
-    for phrase in id_from_phrase:
+    for phrase in box_phrases:
         mask = box_ids == id_from_phrase[phrase]
-        entity_path = f"image/phrases/{phrase}/detections"
-        rr.log_cleared(entity_path)
         rr.log_rects(
-            entity_path,
+            f"image/phrases/{phrase}/detections",
             rects=boxes_filt[mask].numpy(),
             class_ids=box_ids[mask].numpy(),
             rect_format=rr.RectFormat.XYXY,
         )
+
     rr.log_rects(
         "image/detections",
         rects=boxes_filt.numpy(),
@@ -103,6 +102,10 @@ def log_video_segmentation(args, model: GroundingDINO, predictor: Sam):
         rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
         rgb = resize_img(rgb, 512)
         rr.log_image("image", rgb)
+
+        for phrase in id_from_phrase:
+            rr.log_cleared(f"image/phrases/{phrase}/segmentation")
+            rr.log_cleared(f"image/phrases/{phrase}/detections")
         
         detections, phrases = grounding_dino_detect(
             model, args.device, rgb, args.prompt, id_from_phrase

--- a/models.py
+++ b/models.py
@@ -107,9 +107,6 @@ def run_segmentation(
     logging.info("Found {} masks".format(len(masks)))
 
     segmentation_img = np.zeros((image.shape[0], image.shape[1]))
-    for phrase in id_from_phrase:
-        rr.log_cleared(f"image/phrases/{phrase}/segmentation")
-
     phrase_masks = defaultdict(lambda: np.zeros((image.shape[0], image.shape[1])))
 
     for phrase, mask in zip(phrases, masks):

--- a/models.py
+++ b/models.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from collections import defaultdict
 from pathlib import Path
 from typing import Final, List, Mapping
 from urllib.parse import urlparse
@@ -105,14 +106,19 @@ def run_segmentation(
 
     logging.info("Found {} masks".format(len(masks)))
 
-    # Layer all of the masks that belong to a single phrase together
     segmentation_img = np.zeros((image.shape[0], image.shape[1]))
+    for phrase in id_from_phrase:
+        rr.log_cleared(f"image/phrases/{phrase}/segmentation")
+
+    phrase_masks = defaultdict(lambda: np.zeros((image.shape[0], image.shape[1])))
+
     for phrase, mask in zip(phrases, masks):
+        phrase_mask = phrase_masks[phrase]
         segmentation_img[mask.squeeze().numpy(force=True)] = id_from_phrase[phrase]
+        phrase_mask[mask.squeeze().numpy(force=True)] = id_from_phrase[phrase]
+        rr.log_segmentation_image(f"image/phrases/{phrase}/segmentation", phrase_mask)
 
     rr.log_segmentation_image(f"image/segmentation", segmentation_img)
-
-    
 
 
 def is_url(path: str) -> bool:


### PR DESCRIPTION
In addition to logging the full segmentation and all bounding boxes at once, this logs each phrase to a separate entity path. 

This allows to hide specific phrases one-by-one, and also handles overlapping masks (such as person and head) in a better way.